### PR TITLE
Update Lock.sol

### DIFF
--- a/contracts/Lock.sol
+++ b/contracts/Lock.sol
@@ -1,4 +1,3 @@
-// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.9;
 
 contract Lock {
@@ -21,8 +20,10 @@ contract Lock {
         require(block.timestamp >= unlockTime, "You can't withdraw yet");
         require(msg.sender == owner, "You aren't the owner");
 
-        emit Withdrawal(address(this).balance, block.timestamp);
+        uint balance = address(this).balance; // Store the balance in a local variable
 
-        owner.transfer(address(this).balance);
+        emit Withdrawal(balance, block.timestamp);
+
+        owner.transfer(balance); // Use the stored balance for transfer
     }
 }


### PR DESCRIPTION
In this modification, the uint balance = address(this).balance; line stores the contract's balance in a local variable named balance. Then, this variable is used both for emitting the Withdrawal event and for the transfer method. This approach reduces the gas cost because the contract's balance is accessed from memory instead of being fetched from storage multiple times.